### PR TITLE
Move HMAT_CBLAS_XXX to hmatconfig.cmake

### DIFF
--- a/CMake/HMATConfig.cmake.in
+++ b/CMake/HMATConfig.cmake.in
@@ -48,6 +48,10 @@ include("${CMAKE_CURRENT_LIST_DIR}/HMATLibraryDepends.cmake")
 # These are IMPORTED targets created by HMATLibraryDepends.cmake
 set(HMAT_LIBRARIES "@HMAT_LIBRARIES@")
 
+# cblas
+set (HMAT_CBLAS_INCLUDE_DIR "@HMAT_CBLAS_INCLUDE_DIR@")
+set (HMAT_CBLAS_LIBRARIES "@HMAT_CBLAS_LIBRARIES@")
+
 if(CMAKE_VERSION VERSION_LESS 2.8.3)
   set(CMAKE_CURRENT_LIST_DIR)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,9 +223,6 @@ if ((NOT MKL_CBLAS_FOUND) AND (NOT is_debian_openblas))
     endif()
 endif()
 include_directories(${CBLAS_INCLUDE_DIR})
-# It's a mess to detect so we publish it up
-set(HMAT_CBLAS_INCLUDE_DIR ${CBLAS_INCLUDE_DIR} PARENT_SCOPE)
-set(HMAT_CBLAS_LIBRARIES "${BLAS_LIBRARIES};${CBLAS_LIBRARIES}" PARENT_SCOPE)
 
 # ========================
 # Warning flags


### PR DESCRIPTION
Avoids this warning when not used as a subdir project:
```
CMake Warning (dev) at CMakeLists.txt:227 (set):
  Cannot set "HMAT_CBLAS_INCLUDE_DIR": current scope has no parent.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

