### PR TITLE
 Rebased modifications for sparse h-matrices

### DIFF
--- a/include/hmat/hmat.h
+++ b/include/hmat/hmat.h
@@ -376,6 +376,9 @@ typedef struct
   /*! Total number of terms that would be stored if the matrix was not compressed */
   size_t uncompressed_size;
 
+  /*! Memory used to store the matrix. This includes meta data */
+  size_t memory;
+
   /*! Total number of block cluster tree nodes in the HMatrix */
   int nr_block_clusters;
 

--- a/include/hmat/hmat.h
+++ b/include/hmat/hmat.h
@@ -343,9 +343,22 @@ HMAT_API void hmat_delete_admissibility(hmat_admissibility_t * cond);
 /** Information on the HMatrix */
 typedef struct
 {
-  /*! Number of allocated zeros */
-  int full_zeros;
-  /** Total number of terms stored in the full leaves of the HMatrix */
+  /*! Number of allocated zeros & nnz */
+  size_t full_fit_nnz;
+  size_t rk_fit_nnz;
+  size_t rk_square_fit_nnz;
+  size_t full_square_fit_nnz;
+  size_t rk_fit_compressed_size;
+  size_t full_fit_compressed_size;
+  size_t rk_compressed_zeros;
+  size_t rk_compressed_nnz;
+  size_t rk_eval_zeros;
+  size_t rk_eval_nnz;
+  size_t full_zeros;
+  size_t full_nnz;
+  size_t full_as_rk_size;
+  size_t rk_as_full_size;
+  /* ! Total number of terms stored in the full leaves of the HMatrix */
   size_t full_size;
 
   /** @deprecated Use compressed_size, uncompressed_size or full_size */

--- a/src/admissibility.cpp
+++ b/src/admissibility.cpp
@@ -58,10 +58,10 @@ StandardAdmissibilityCondition::StandardAdmissibilityCondition(
 std::pair<bool, bool>
 StandardAdmissibilityCondition::splitRowsCols(const ClusterTree& rows, const ClusterTree& cols) const
 {
-  if (cols.data.size() < ratio_ * rows.data.size() ) {
+  if (cols.data.size() < ratio_ * rows.data.size()  && cols.isLeaf()) {
     // rows are two times larger than cols so we won't subdivide cols
     return std::pair<bool, bool>(!rows.isLeaf(), false);
-  } else if (rows.data.size() < ratio_ * cols.data.size() ) {
+  } else if (rows.data.size() < ratio_ * cols.data.size()  && rows.isLeaf()) {
     // cols are two times larger than rows so we won't subdivide rows
     return std::pair<bool, bool>(false, !cols.isLeaf());
   } else // approximately the same size, we can subdivide both

--- a/src/admissibility.cpp
+++ b/src/admissibility.cpp
@@ -58,21 +58,26 @@ StandardAdmissibilityCondition::StandardAdmissibilityCondition(
 std::pair<bool, bool>
 StandardAdmissibilityCondition::splitRowsCols(const ClusterTree& rows, const ClusterTree& cols) const
 {
-  if (cols.data.size() < ratio_ * rows.data.size()  && cols.isLeaf()) {
+  if (cols.data.size() <= ratio_ * rows.data.size()  && cols.isLeaf() ) {
     // rows are two times larger than cols so we won't subdivide cols
     return std::pair<bool, bool>(!rows.isLeaf(), false);
-  } else if (rows.data.size() < ratio_ * cols.data.size()  && rows.isLeaf()) {
+  } else if (rows.data.size() <= ratio_ * cols.data.size()  && rows.isLeaf()) {
     // cols are two times larger than rows so we won't subdivide rows
     return std::pair<bool, bool>(false, !cols.isLeaf());
+  } else if (rows.isLeaf() || cols.isLeaf()) {
+    // approximately the same size, but one is a leaf so we forbid subdivision for both
+    return std::pair<bool, bool>(false, false);
   } else // approximately the same size, we can subdivide both
-  return std::pair<bool, bool>(!rows.isLeaf(), !cols.isLeaf());
+    return std::pair<bool, bool>(true, true);
 }
 
 bool
 StandardAdmissibilityCondition::stopRecursion(const ClusterTree& rows, const ClusterTree& cols) const
 {
+    // If we do not want to split rows nor cols, we must stop recursion (to allow Rk)
+    std::pair<bool, bool> split = splitRowsCols(rows, cols);
     // If there is less than 2 rows or cols, recursion is useless
-    return (rows.data.size() < 2 || cols.data.size() < 2);
+    return (rows.data.size() < 2 || cols.data.size() < 2 || (!split.first && !split.second));
 }
 
 bool

--- a/src/cluster_tree.cpp
+++ b/src/cluster_tree.cpp
@@ -155,8 +155,6 @@ ClusterTree::slice(int offset, int size) const
   ClusterTree* result = new ClusterTree(*this);
   result->data.offset_ = offset;
   result->data.size_ = size;
-  result->clusteringAlgoData_ = NULL;
-  result->admissibilityAlgoData_ = NULL;
   return result;
 }
 
@@ -248,4 +246,3 @@ AxisAlignedBoundingBox::distanceTo(const AxisAlignedBoundingBox& other) const
 }
 
 }  // end namespace hmat
-

--- a/src/common/context.cpp
+++ b/src/common/context.cpp
@@ -54,6 +54,8 @@ namespace trace {
   bool Node::enabled = true;
   UM_NS::unordered_map<void*, Node*> Node::currentNodes[MAX_ROOTS];
   void* Node::enclosingContext[MAX_ROOTS] = {};
+  const char* Node::flops_count_filename = "data.flops";
+  std::ofstream flops_count_stream(Node::flops_count_filename);
 
   Node::Node(const char* _name, Node* _parent)
     : name_(_name), data(), parent(_parent), children() {}
@@ -89,6 +91,9 @@ namespace trace {
     assert(current);
 
     current->data.totalTime += time_diff_in_nanos(current->data.lastEnterTime, now());
+    static char * flopStudy = getenv("HMAT_FLOP_STUDY");
+    if (flopStudy)
+      flops_count_stream << " time " << time_diff_in_nanos(current->data.lastEnterTime, now())<< std::endl;
 
     if (!(current->parent)) {
       std::cout << "Warning! Closing root node." << std::endl;
@@ -108,6 +113,9 @@ namespace trace {
 
   void Node::incrementFlops(int64_t flops) {
     currentNode()->data.totalFlops += flops;
+    static char * flopStudy = getenv("HMAT_FLOP_STUDY");
+    if (flopStudy)
+      flops_count_stream << currentNode()->name_ << " flops " << flops << " ";
   }
 
   void Node::startComm() {

--- a/src/common/context.hpp
+++ b/src/common/context.hpp
@@ -83,6 +83,7 @@ namespace trace {
   public:
     /// True if the tracing is enabled. True by default. Not used anywhere, apparently...
     static bool enabled;
+    static const char* flops_count_filename;
   private:
     /// Unique name for the context.
     const char* name_;
@@ -95,6 +96,7 @@ namespace trace {
     /// List of trace trees.
     static UM_NS::unordered_map<void*, Node*> currentNodes[MAX_ROOTS]; // TODO: padding to avoid false sharing ?
     static void* enclosingContext[MAX_ROOTS]; // TODO: padding to avoid false sharing ?
+
 
   public:
     /** Enter a context noted by a name.

--- a/src/full_matrix.cpp
+++ b/src/full_matrix.cpp
@@ -109,6 +109,31 @@ template<typename T> size_t FullMatrix<T>::storedZeros() {
   return data.storedZeros();
 }
 
+template<typename T> size_t FullMatrix<T>::info(hmat_info_t & result, size_t& rowsMin, size_t& colsMin, size_t& rowsMax, size_t& colsMax) {
+  size_t colsCount = 0, rowsCount = 0;
+  colsMax = 0;
+  colsMin = cols();
+  rowsMax = 0;
+  rowsMin = rows();
+  bool* notNullRows = (bool*) calloc(rows(), sizeof(bool));
+  bool* notNullCols = (bool*) calloc(cols(), sizeof(bool));
+  for (int col = 0; col < cols(); col++) {
+    for (int row = 0; row < rows(); row++) {
+      if (std::abs(get(row, col)) > 1e-16) {
+        rowsMin = (rowsMin < row) ? rowsMin : row;
+        rowsMax = (rowsMax > row) ? rowsMax : row;
+        colsMin = (colsMin < col) ? colsMin : col;
+        colsMax = (colsMax > col) ? colsMax : col;
+        if (!notNullRows[row]) rowsCount++;
+        if (!notNullCols[col]) colsCount++;
+        notNullRows[row] = true;
+        notNullCols[col] = true;
+      }
+    }
+  }
+  return colsCount * rowsCount;
+}
+
 template<typename T> void FullMatrix<T>::scale(T alpha) {
   data.scale(alpha);
   if (diagonal)

--- a/src/full_matrix.hpp
+++ b/src/full_matrix.hpp
@@ -114,6 +114,9 @@ public:
   /** \brief Returns number of allocated zeros
    */
   size_t storedZeros();
+  /** \brief Returns some info about block, like size of square that fit nnz locality (i.e all null rows/cols ignored)
+   */
+  size_t info(hmat_info_t & result, size_t& rowsMin, size_t& colsMin, size_t& rowsMax, size_t& colsMax);
   /** \brief this *= alpha.
 
       \param alpha The scaling factor.

--- a/src/h_matrix.cpp
+++ b/src/h_matrix.cpp
@@ -395,9 +395,44 @@ template<typename T> void HMatrix<T>::info(hmat_info_t & result) {
     } else if(this->isLeaf()) {
         size_t s = ((size_t)r) * c;
         result.uncompressed_size += s;
+        size_t rowsMin, colsMin, rowsMax, colsMax;
+        static char * fitStudy = getenv("HMAT_FIT_STUDY");
         if(isRkMatrix()) {
             size_t mem = rank() * (((size_t)r) + c);
             result.compressed_size += mem;
+            if(!rk())
+                rk(new RkMatrix<T>(NULL, rows(), NULL, cols(), NoCompression));
+
+            if (fitStudy) {
+              FullMatrix<T>* rk_eval = rk()->eval();
+              result.rk_fit_nnz += rk_eval->info(result, rowsMin, colsMin, rowsMax, colsMax);
+              if (colsMax == 0) {
+                colsMax = cols()->size();
+                colsMin = 0;
+                rowsMax = rows()->size();
+                rowsMin = 0;
+              } else
+              result.rk_square_fit_nnz += (colsMax - colsMin) * (rowsMax - rowsMin);
+
+              HMatrix<T> * tmpMatrix = new HMatrix<T>(this->localSettings.global);
+              tmpMatrix->temporary_=true;
+              tmpMatrix->ownClusterTrees(true, true);
+              ClusterTree * rows_subset = rows_->slice(rows()->offset() + rowsMin, rowsMax - rowsMin);
+              ClusterTree * cols_subset = cols_->slice(cols()->offset() + colsMin, colsMax - colsMin);
+              rows_subset->father = rows_subset;
+              cols_subset->father = cols_subset;
+              tmpMatrix->rows_ = rows_subset;
+              tmpMatrix->cols_ = cols_subset;
+              RkMatrix<T>* newRk = const_cast<RkMatrix<T>*>(rk()->subset(tmpMatrix->rows(), tmpMatrix->cols()));
+              result.rk_fit_compressed_size += newRk->rank() * (((size_t)newRk->rows->size()) + newRk->cols->size());
+              size_t rk_eval_zeros = rk_eval->storedZeros();
+              size_t rk_compressed_zeros = rk()->storedZeros();
+              result.rk_as_full_size += rk()->uncompressedSize();
+              result.rk_eval_zeros += rk_eval_zeros;
+              result.rk_eval_nnz += s - rk_eval_zeros;
+              result.rk_compressed_zeros += rk_compressed_zeros;
+              result.rk_compressed_nnz += mem - rk_compressed_zeros;
+            }
             int dim = result.largest_rk_dim_cols + result.largest_rk_dim_rows;
             if(rows()->size() + cols()->size() > dim) {
                 result.largest_rk_dim_cols = c;
@@ -413,9 +448,33 @@ template<typename T> void HMatrix<T>::info(hmat_info_t & result) {
             result.rk_count++;
             result.rk_size += s;
         } else {
+          if (isFullMatrix()) {
+            result.full_zeros += full()->storedZeros();
+            if (fitStudy) {
+              result.full_nnz += s - full()->storedZeros();
+              size_t fit = full()->info(result, rowsMin, colsMin, rowsMax, colsMax);
+              result.full_fit_nnz += fit;
+              result.full_square_fit_nnz += (colsMax+1 - colsMin) * (rowsMax+1 - rowsMin);
+              RkMatrix<T>* rk = truncatedSvd(full()->copy());
+              result.full_as_rk_size += rk->compressedSize();
+              HMatrix<T> * tmpMatrix = new HMatrix<T>(this->localSettings.global);
+              tmpMatrix->temporary_=true;
+              tmpMatrix->ownClusterTrees(true, true);
+              ClusterTree * r = rows_->slice(rows()->offset() + rowsMin, rowsMax - rowsMin);
+              ClusterTree * c = cols_->slice(cols()->offset() + colsMin, colsMax - colsMin);
+              r->father = r;
+              c->father = c;
+              tmpMatrix->rows_ = r;
+              tmpMatrix->cols_ = c;
+              RkMatrix<T>* newRk = const_cast<RkMatrix<T>*>(rk->subset(tmpMatrix->rows(), tmpMatrix->cols()));
+              result.full_fit_compressed_size += newRk->rank() * (((size_t)newRk->rows->size()) + newRk->cols->size());
+              delete newRk;
+              delete tmpMatrix;
+            }
             result.compressed_size += s;
             result.full_count ++;
             result.full_size += s;
+          }
         }
     } else {
         for (int i = 0; i < this->nrChild(); i++) {

--- a/src/h_matrix.cpp
+++ b/src/h_matrix.cpp
@@ -749,7 +749,6 @@ void HMatrix<T>::gemv(char matTrans, T alpha, const ScalarArray<T>* x, T beta, S
           ScalarArray<T> subY(y->rowsSubset(rowsOffset, rowsSize));
           child->gemv(trans, alpha, &subX, Constants<T>::pone, &subY);
         }
-        else continue;
       }
 
   } else {
@@ -1254,7 +1253,8 @@ HMatrix<T>::leafGemm(char transA, char transB, T alpha, const HMatrix<T>* a, con
 template<typename T>
 void HMatrix<T>::gemm(char transA, char transB, T alpha, const HMatrix<T>* a, const HMatrix<T>* b, T beta, MainOp) {
   // Computing a(m,0) * b(0,n) here may give wrong results because of format conversions, exit early
-  if(isVoid() || a->isVoid())
+  if (a && b) {
+  if (isVoid() || a->isVoid())
       return;
 
   // This and B are Rk matrices with the same panel 'b' -> the gemm is only applied on the panels 'a'
@@ -1289,7 +1289,10 @@ void HMatrix<T>::gemm(char transA, char transB, T alpha, const HMatrix<T>* a, co
     return;
   }
 
+} else {
   this->scale(beta);
+  return;
+}
 
   if((a->isLeaf() && a->isNull()) || (b->isLeaf() && b->isNull())) {
       if(!isAssembled() && this->isLeaf())

--- a/src/h_matrix.cpp
+++ b/src/h_matrix.cpp
@@ -994,7 +994,7 @@ template<typename T> HMatrix<T> * HMatrix<T>::subset(
         tmpMatrix->ownClusterTrees(true, true);
         if(this->isRkMatrix()) {
           tmpMatrix->rk(const_cast<RkMatrix<T>*>(rk()->subset(tmpMatrix->rows(), tmpMatrix->cols())));
-        } else {
+        } else if (this->isFullMatrix()) {
           tmpMatrix->full(const_cast<FullMatrix<T>*>(full()->subset(tmpMatrix->rows(), tmpMatrix->cols())));
         }
         return tmpMatrix;

--- a/src/h_matrix.cpp
+++ b/src/h_matrix.cpp
@@ -639,8 +639,11 @@ bool HMatrix<T>::coarsen(HMatrix<T>* upper) {
   // leaves. Note that this operation could be used hierarchically.
 
   bool allRkLeaves = true;
-  const RkMatrix<T>* childrenArray[this->nrChild()];
+  int n = 0;
+  for (int i = 0; i < this->nrChild(); i++) if (this->getChild(i)) n++;
+  const RkMatrix<T>* childrenArray[n];
   size_t childrenElements = 0;
+  int j = 0;
   for (int i = 0; i < this->nrChild(); i++) {
     HMatrix<T> *child = this->getChild(i);
     if (!child) continue;
@@ -648,15 +651,16 @@ bool HMatrix<T>::coarsen(HMatrix<T>* upper) {
       allRkLeaves = false;
       break;
     } else {
-      childrenArray[i] = child->rk();
-      childrenElements += (childrenArray[i]->rows->size()
-                           + childrenArray[i]->cols->size()) * childrenArray[i]->rank();
+      childrenArray[j] = child->rk();
+      childrenElements += (childrenArray[j]->rows->size()
+                           + childrenArray[j]->cols->size()) * childrenArray[j]->rank();
     }
+    j++;
   }
   if (allRkLeaves) {
-    std::vector<T> alpha(this->nrChild(), Constants<T>::pone);
+    std::vector<T> alpha(n, Constants<T>::pone);
     RkMatrix<T> dummy(NULL, rows(), NULL, cols(), NoCompression);
-    RkMatrix<T>* candidate = dummy.formattedAddParts(&alpha[0], childrenArray, this->nrChild());
+    RkMatrix<T>* candidate = dummy.formattedAddParts(&alpha[0], childrenArray, n);
     size_t elements = (((size_t) candidate->rows->size()) + candidate->cols->size()) * candidate->rank();
     if (elements < childrenElements) {
       // Replace 'this' by the new Rk matrix

--- a/src/h_matrix.cpp
+++ b/src/h_matrix.cpp
@@ -1199,6 +1199,13 @@ HMatrix<T>::leafGemm(char transA, char transB, T alpha, const HMatrix<T>* a, con
             rk(new RkMatrix<T>(NULL, rows(), NULL, cols(), NoCompression));
         rk()->gemmRk(transA, transB, alpha, a, b, Constants<T>::pone);
         rank_ = rk()->rank();
+        if (rk()->compressedSize() > rk()->uncompressedSize()){
+          FullMatrix<T>* fullMat = rk()->eval();
+          delete rk();
+          full(fullMat);
+          rank_=-1;
+        }
+
         return;
     }
 

--- a/src/h_matrix.cpp
+++ b/src/h_matrix.cpp
@@ -388,6 +388,7 @@ void HMatrix<T>::assembleSymmetric(Assembly<T>& f,
 
 template<typename T> void HMatrix<T>::info(hmat_info_t & result) {
     result.nr_block_clusters++;
+    result.memory += sizeof(*this);
     int r = rows()->size();
     int c = cols()->size();
     if(r == 0 || c == 0) {
@@ -404,6 +405,8 @@ template<typename T> void HMatrix<T>::info(hmat_info_t & result) {
                 rk(new RkMatrix<T>(NULL, rows(), NULL, cols(), NoCompression));
 
             if (fitStudy) {
+              result.memory += mem*sizeof(T);
+              result.memory += sizeof(*rk());
               FullMatrix<T>* rk_eval = rk()->eval();
               result.rk_fit_nnz += rk_eval->info(result, rowsMin, colsMin, rowsMax, colsMax);
               if (colsMax == 0) {
@@ -449,6 +452,9 @@ template<typename T> void HMatrix<T>::info(hmat_info_t & result) {
             result.rk_size += s;
         } else {
           if (isFullMatrix()) {
+            result.memory += sizeof(*full());
+            result.memory += s*sizeof(T);
+
             result.full_zeros += full()->storedZeros();
             if (fitStudy) {
               result.full_nnz += s - full()->storedZeros();

--- a/src/h_matrix.cpp
+++ b/src/h_matrix.cpp
@@ -1261,7 +1261,7 @@ template<typename T>
 void HMatrix<T>::gemm(char transA, char transB, T alpha, const HMatrix<T>* a, const HMatrix<T>* b, T beta, MainOp) {
   // Computing a(m,0) * b(0,n) here may give wrong results because of format conversions, exit early
   if (a && b) {
-  if (isVoid() || a->isVoid())
+    if (isVoid() || a->isVoid())
       return;
 
   // This and B are Rk matrices with the same panel 'b' -> the gemm is only applied on the panels 'a'
@@ -1295,11 +1295,10 @@ void HMatrix<T>::gemm(char transA, char transB, T alpha, const HMatrix<T>* a, co
     b->gemv(transB == 'N' ? 'T' : 'N', alpha, &aSubset, beta, &cSubset);
     return;
   }
-
-} else {
+  }
   this->scale(beta);
-  return;
-}
+
+  if (!a || !b) return;
 
   if((a->isLeaf() && a->isNull()) || (b->isLeaf() && b->isNull())) {
       if(!isAssembled() && this->isLeaf())

--- a/src/h_matrix.hpp
+++ b/src/h_matrix.hpp
@@ -550,7 +550,7 @@ public:
   HMatrix<T>* get(int i, int j) const {
     assert(i>=0 && i<nrChildRow());
     assert(j>=0 && j<nrChildCol());
-    assert(i + j * nrChildRow() < this->nrChild());
+    // assert(i + j * nrChildRow() < this->nrChild()); This assertion will be done inside this->getChild()
     return this->getChild(i + j * nrChildRow());
   }
 

--- a/src/hmat_cpp_interface.cpp
+++ b/src/hmat_cpp_interface.cpp
@@ -201,6 +201,11 @@ double HMatInterface<T, E>::norm() const {
 }
 
 template<typename T, template <typename> class E>
+void HMatInterface<T, E>::eval(FullMatrix<T>* result, bool renumber) const {
+  engine_.hmat->eval(result, renumber);
+}
+
+template<typename T, template <typename> class E>
 void HMatInterface<T, E>::scale(T alpha) {
   DISABLE_THREADING_IN_BLOCK;
   DECLARE_CONTEXT;
@@ -263,4 +268,3 @@ void HMatInterface<T, E>::apply_on_leaf(const LeafProcedure<HMatrix<T> >& proc){
 }
 
 } // end namespace hmat
-

--- a/src/hmat_cpp_interface.hpp
+++ b/src/hmat_cpp_interface.hpp
@@ -269,6 +269,16 @@ public:
   /** Return an approximation of the Frobenius norm of this.
    */
   double norm() const;
+  /*! \brief Evaluate the HMatrix, ie converts it to a full matrix.
+
+    This conversion does the reorderng of the unknowns such that the resulting
+    matrix can directly be used or compared with a full matrix assembled
+    otherwise.
+
+    \param result a FullMatrix that has to be preallocated at the same size than
+    this.
+   */
+  void eval(FullMatrix<T>* result, bool renumber = true) const;
   /** this <- alpha * this
    */
   void scale(T alpha);

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -127,7 +127,9 @@ template<typename T> void HMatrixJSONDumper<T>::update() {
     cols_ = current_->cols();
     nrChild_ = current_->nrChild();
     if (current_->isFullMatrix()) {
-        nodeInfo_ << " \"leaf_type\": \"Full\"";
+        int zeros = current_->full()->storedZeros();
+        double ratio = zeros / ((double) current_->full()->rows() * current_->full()->cols());
+        nodeInfo_ << " \"leaf_type\": \"Full\", \"k\": " << 1-ratio;
     } else if (current_->isRkMatrix() && current_->rk()) {
         nodeInfo_ << " \"leaf_type\": \"Rk\", \"k\": " << current_->rank() << ",";
         nodeInfo_ << " \"method\": " << current_->rk()->method;

--- a/src/postscript.cpp
+++ b/src/postscript.cpp
@@ -188,9 +188,12 @@ void PostscriptDumper<T>::drawMatrix(const void *tree, ofstream& f, int depth, b
         if (m->isRkMatrix() && !m->isNull() && m->rk() != NULL) {
             double ratio = m->rk()->compressedSize() / (double) m->rk()->uncompressedSize();
             double color = 0;
-            if (ratio < .20) {
-                color = 1 - 5 * ratio;
-            }
+            double ratioMax = .8;
+            double colorMin = .5;
+            if (ratio >= 1) colorMin = 0;
+            else if (ratio < ratioMax) {
+                color = 1 - (1-colorMin)/ratioMax * ratio;
+            } else color = colorMin;
             f << 0 << " "<< -lengthY << " "
               << -lengthX << " " << 0 << " "
               << 0 << " " << lengthY << " "

--- a/src/postscript.cpp
+++ b/src/postscript.cpp
@@ -60,7 +60,7 @@ static double writeHeader(ofstream & file, int maxDim)
          << "/grayrectangle {" << endl
          << "        newpath" << endl
          << "	     setlinewidth"  << endl
-         << "        0.83 setgray" << endl
+         << "        1 setgray" << endl
          << "        moveto" << endl
          << "        rlineto" << endl
          << "        rlineto" << endl
@@ -190,7 +190,7 @@ void PostscriptDumper<T>::drawMatrix(const void *tree, ofstream& f, int depth, b
             double color = 0;
             double ratioMax = .8;
             double colorMin = .5;
-            if (ratio >= 1) colorMin = 0;
+            if (ratio >= 1) color = 0;
             else if (ratio < ratioMax) {
                 color = 1 - (1-colorMin)/ratioMax * ratio;
             } else color = colorMin;
@@ -216,13 +216,15 @@ void PostscriptDumper<T>::drawMatrix(const void *tree, ofstream& f, int depth, b
               << 0 << " " << lengthY << " "
               << lengthX << " " << 0 << " "
               << startX << " " << startY;
+            int value = (int) ceil(100 * (1-ratio));
             if (ratio < 0.8)
               f << " " << max((0.2+ratio),0.6) << " 0 0";
+            else if (value == 0)
+            f << " " << "1 1 0";
             else
               f << " " << "1 " << color << " " << color;
             f << " redrectangle" << endl;
             // value to write: percentage of non-zeros
-            int value = (int) (100 * (1-ratio));
             // size of the characters
             double size= (value>=100?.5:0.7) * min(-lengthY,lengthX);
             f << startX + 10 - depth << " " << startY + (lengthY * .75) << " " << size
@@ -233,10 +235,10 @@ void PostscriptDumper<T>::drawMatrix(const void *tree, ofstream& f, int depth, b
              << 0 << " " << lengthY << " "
              << lengthX << " " << 0 << " "
              << startX << " " << startY;
-           f << " 1 1 1 "
+             f << " .9 .9 .9"
              << " greenrectangle" << endl;
-           f << startX << " " << startY + (lengthY * .95) << " " << .7 * std::min(lengthX, - lengthY)
-             << " (" << 0 << ") showrank" << endl;
+          //  f << startX << " " << startY + (lengthY * .95) << " " << .7 * std::min(lengthX, - lengthY)
+          //    << " (" << 0 << ") showrank" << endl;
        }
     } else if(cross){ /* true pour une hmat, !(handle->position == kAboveL0) pour une HMatrixHandle */
         n = m->rows()->coordinates()->size();

--- a/src/recursion.cpp
+++ b/src/recursion.cpp
@@ -74,7 +74,7 @@ namespace hmat {
         // Hij <- Hij - Lik Dk tLjk
         // if i=j, we can use mdmtProduct, otherwise we use mdntProduct
         for (int j=k+1 ; j<i ; j++)
-          if (me()->get(i,j) && me()->get(j,k))
+          if (me()->get(i,k) && me()->get(j,k))
             me()->get(i,j)->mdntProduct(me()->get(i,k), me()->get(k,k), me()->get(j,k)); // hij -= Lik.Dk.tLjk
         me()->get(i,i)->mdmtProduct(me()->get(i,k), me()->get(k,k)); //  hii -= Lik.Dk.tLik
       }
@@ -102,11 +102,11 @@ namespace hmat {
       for (int k=0 ; k<b->nrChildRow() ; k++) // loop on the lines of b
         for (int i=0 ; i<me()->nrChildRow() ; i++) {
           // Update b[k,i] with the contribution of the solutions already computed b[k,j] j<i
-          if (!b->get(k, i)) continue;
           for (int j=0 ; j<i ; j++)
             if (b->get(k, j) && (lowerStored ? me()->get(i,j) : me()->get(j,i)))
               b->get(k, i)->gemm('N', lowerStored ? 'T' : 'N', Constants<T>::mone, b->get(k, j), lowerStored ? me()->get(i,j) : me()->get(j,i), Constants<T>::pone);
           // Solve the i-th diagonal system
+          if (b->get(k,i))
           me()->get(i, i)->solveUpperTriangularRight(b->get(k,i), unitriangular, lowerStored);
         }
 
@@ -154,7 +154,7 @@ namespace hmat {
           if (!m->get(i,0))
             continue;
           for (int j=0 ; j<i ; j++)
-            if (me()->get(i,j) && m->get(j,0))
+            if (m->get(j,0))
               me()->get(i,j)->mdntProduct(m->get(i,0), d, m->get(j,0)); // hij -= Mi0.D.tMj0
           me()->get(i,i)->mdmtProduct(m->get(i,0),  d);               // hii -= Mi0.D.tMi0
         }
@@ -167,7 +167,7 @@ namespace hmat {
               continue;
             const Mat* d_k = d->get(k,k);
             for (int j=0 ; j<i ; j++)
-              if (me()->get(i,j) && m->get(j,k))
+              if (m->get(j,k))
                 me()->get(i,j)->mdntProduct(m_ik, d_k, m->get(j,k)); // hij -= Mik.Dk.tMjk
             me()->get(i,i)->mdmtProduct(m_ik, d_k); //  hii -= Mik.Dk.tMik
           }
@@ -270,7 +270,7 @@ namespace hmat {
       for (int i=k+1 ; i<me()->nrChildRow() ; i++)
         for (int j=k+1 ; j<me()->nrChildRow() ; j++)
           // Hij <- Hij - Lik Ukj
-          if (me()->get(i,j) && me()->get(i,k) && me()->get(k,j))
+          if (me()->get(i,k) && me()->get(k,j))
           me()->get(i,j)->gemm('N', 'N', Constants<T>::mone, me()->get(i,k), me()->get(k,j), Constants<T>::pone);
     }
 

--- a/src/recursion.cpp
+++ b/src/recursion.cpp
@@ -103,10 +103,10 @@ namespace hmat {
         for (int i=0 ; i<me()->nrChildRow() ; i++) {
           // Update b[k,i] with the contribution of the solutions already computed b[k,j] j<i
           for (int j=0 ; j<i ; j++)
-            if (b->get(k, j) && (lowerStored ? me()->get(i,j) : me()->get(j,i)))
+            if (b->get(k, i))
               b->get(k, i)->gemm('N', lowerStored ? 'T' : 'N', Constants<T>::mone, b->get(k, j), lowerStored ? me()->get(i,j) : me()->get(j,i), Constants<T>::pone);
           // Solve the i-th diagonal system
-          if (b->get(k,i))
+          if (me()->get(i,i) && b->get(k,i))
           me()->get(i, i)->solveUpperTriangularRight(b->get(k,i), unitriangular, lowerStored);
         }
 

--- a/src/rk_matrix.cpp
+++ b/src/rk_matrix.cpp
@@ -958,6 +958,7 @@ template<typename T> void RkMatrix<T>::gemmRk(char transHA, char transHB,
     int nbCols = transHB == 'N' ? hb->nrChildCol() : hb->nrChildRow() ; /* Col blocks of the product */
     int nbCom  = transHA == 'N' ? ha->nrChildCol() : ha->nrChildRow() ; /* Common dimension between A and B */
     RkMatrix<T>* subRks[nbRows * nbCols];
+    bool subRksNull = true;
     for (int i = 0; i < nbRows; i++) {
       for (int j = 0; j < nbCols; j++) {
         subRks[i + j * nbRows]=(RkMatrix<T>*)NULL;
@@ -972,10 +973,14 @@ template<typename T> void RkMatrix<T>::gemmRk(char transHA, char transHB,
               subRks[i + j * nbRows] = new RkMatrix<T>(NULL, subRows, NULL, subCols, NoCompression);
             }
             subRks[i + j * nbRows]->gemmRk(transHA, transHB, alpha, a_ik, b_kj, beta);
+            subRksNull = false;
           }
         } // k loop
       } // j loop
     } // i loop
+    // if ha and hb have no 'compatible' children, subRks is null
+    if (subRksNull)
+      return;
     // Reconstruction of C by adding the parts
     std::vector<T> alphaV(nbRows * nbCols, Constants<T>::pone);
     RkMatrix<T>* rk = formattedAddParts(&alphaV[0], (const RkMatrix<T>**) subRks, nbRows * nbCols);

--- a/src/rk_matrix.cpp
+++ b/src/rk_matrix.cpp
@@ -507,8 +507,12 @@ RkMatrix<T>* RkMatrix<T>::formattedAddParts(const T* alpha, const RkMatrix<T>* c
     const IndexSet** rowsParts = new const IndexSet*[n];
     const IndexSet** colsParts = new const IndexSet*[n];
     for (int i = 0; i < n; i++) {
-      if (!parts[i])
+      if (!parts[i]) {
+        fullParts[i] = NULL;
+        rowsParts[i] = NULL;
+        colsParts[i] = NULL;
         continue;
+      }
       fullParts[i] = parts[i]->eval();
       rowsParts[i] = parts[i]->rows;
       colsParts[i] = parts[i]->cols;

--- a/src/rk_matrix.cpp
+++ b/src/rk_matrix.cpp
@@ -196,6 +196,15 @@ template<typename T> void RkMatrix<T>::addRand(double epsilon) {
   return;
 }
 
+template<typename T> size_t RkMatrix<T>::storedZeros() {
+  size_t result = 0;
+  if (a)
+    result += a->storedZeros() ;
+  if (b)
+    result += b->storedZeros() ;
+  return result;
+}
+
 template<typename T> void RkMatrix<T>::truncate(double epsilon) {
   DECLARE_CONTEXT;
 

--- a/src/rk_matrix.cpp
+++ b/src/rk_matrix.cpp
@@ -949,41 +949,6 @@ template<typename T> void RkMatrix<T>::gemmRk(char transHA, char transHB,
   // TODO: remove this limitation, if needed.
   assert(beta == Constants<T>::pone);
 
-  // This is ugly!  When ha node is void, we replace ha by its non-void child
-  // so that further computations are similar to the non-void case.
-  // Indeed, this is ugly...
-  while (!ha->isLeaf())
-  {
-    if (ha->nrChildRow() >= 2 && ha->nrChildCol() >= 2) {
-      if (ha->get(0, 0)->rows()->size() == 0 && ha->get(0, 0)->cols()->size() == 0)
-      {
-        ha = ha->get(1, 1);
-        continue;
-      }
-      if (ha->get(1, 1) && ha->get(1, 1)->rows()->size() == 0 && ha->get(1, 1)->cols()->size() == 0)
-      {
-        ha = ha->get(0, 0);
-        continue;
-      }
-    }
-    break;
-  }
-  while (!hb->isLeaf())
-  {
-    if (hb->nrChildRow() >= 2 && hb->nrChildCol() >= 2) {
-      if (hb->get(0, 0)->rows()->size() == 0 && hb->get(0, 0)->cols()->size() == 0)
-      {
-        hb = hb->get(1, 1);
-        continue;
-      }
-      if (hb->get(1, 1) && hb->get(1, 1)->rows()->size() == 0 && hb->get(1, 1)->cols()->size() == 0)
-      {
-        hb = hb->get(0, 0);
-        continue;
-      }
-    }
-    break;
-  }
   // void matrix
   if (ha->rows()->size() == 0 || ha->cols()->size() == 0 || hb->rows()->size() == 0 || hb->cols()->size() == 0) return;
 

--- a/src/rk_matrix.hpp
+++ b/src/rk_matrix.hpp
@@ -127,6 +127,9 @@ public:
        \return pointer to a new matrix with subRows and subCols.
    */
   const RkMatrix* subset(const IndexSet* subRows, const IndexSet* subCols) const;
+  /** \brief Returns number of allocated zeros
+   */
+  size_t storedZeros();
   /** Returns the compression ratio (stored_elements, total_elements).
    */
   size_t compressedSize();

--- a/src/scalar_array.cpp
+++ b/src/scalar_array.cpp
@@ -262,6 +262,7 @@ template<typename T>
 void ScalarArray<T>::gemm(char transA, char transB, T alpha,
                          const ScalarArray<T>* a, const ScalarArray<T>* b,
                          T beta) {
+DECLARE_CONTEXT;
   int aRows  = (transA == 'N' ? a->rows : a->cols);
   int n  = (transB == 'N' ? b->cols : b->rows);
   int k  = (transA == 'N' ? a->cols : a->rows);


### PR DESCRIPTION
Changes in info() give extra information such as the potential memory a rk-matrix could benefit from being stored as a full-matrix and vice-versa.