### PR TITLE
Fix undeclared openblas_set_num_threads

### DIFF
--- a/src/disable_threading.cpp
+++ b/src/disable_threading.cpp
@@ -36,6 +36,7 @@
 extern "C" {
 // This function is private in openblas
 int  goto_get_num_procs(void);
+void openblas_set_num_threads(int num_threads);
 }
 #endif
 


### PR DESCRIPTION
I cannot compile with openblas:
```
disable_threading.cpp:60:5: error: use of undeclared identifier 'openblas_set_num_threads'
    openblas_set_num_threads(1);
```