### PR TITLE
Allow to use openblas without its headers

### DIFF
--- a/src/disable_threading.cpp
+++ b/src/disable_threading.cpp
@@ -32,10 +32,11 @@
 #endif
 
 #ifdef OPENBLAS_DISABLE_THREADS
-#include <cblas.h>
 extern "C" {
 // This function is private in openblas
 int  goto_get_num_procs(void);
+// This function is public but we may use netlib's cblas.h header instead of openblas header
+void openblas_set_num_threads(int);
 }
 #endif
 


### PR DESCRIPTION
Sometimes we just drop the openblas lib without modifying the headers,
so cblas.h may not contain the openblas_set_num_threads declaration
eventhough cmake found it in the lib.