### PR TITLE
Workaround for a bug occuring when compiling with MKL

### DIFF
--- a/src/scalar_array.cpp
+++ b/src/scalar_array.cpp
@@ -999,6 +999,16 @@ int ScalarArray<T>::productQ(char side, char trans, ScalarArray<T>* c) const {
   info = proxy_lapack_convenience::or_un_mqr(side, trans, c->rows, c->cols, cols, const_ptr(), lda, tau, c->m, c->lda, &workSize_req, -1);
   HMAT_ASSERT(!info);
   workSize = (int) hmat::real(workSize_req) + 1;
+
+  // If the previous call to 'or_un_mqr' does not give us a large enough work
+  // space size, we set the latter to the count of rows or columns of the matrix
+  // depending on the value of 'side'. 
+  if(side == 'L') {
+    workSize = workSize < c->rows ? c->rows : workSize;
+  } else if(side == 'R') {
+    workSize = workSize < c->cols ? c->cols : workSize;
+  }
+
   T* work = new T[workSize];
   HMAT_ASSERT(work);
   info = proxy_lapack_convenience::or_un_mqr(side, trans, c->rows, c->cols, cols, const_ptr(), lda, tau, c->m, c->lda, work, workSize);


### PR DESCRIPTION
While doing benchmarks, I experienced MKL errors coming from the routine `productQ` in _scalar_array.cpp_. When using sparse FEM matrices with row/column count above 9503, the first call to `or_un_mqr` in the routine computes a wrong (too small: 1) `workSize` value which makes subsequent asserts fail. I implemented a little workaround as suggested by @gsylvand. If the value of `workSize` returned by `or_un_mqr` is smaller than the row/column count the latter is attributed to `workSize` depending on the value of side.

For now, we are not sure about the origin of the problem although we already suspect several origins possible.