### PR TITLE
Fix leak in doCompressionAcaPartial

### DIFF
--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -394,6 +394,7 @@ doCompressionAcaPartial(const ClusterAssemblyFunction<T>& block, double compress
     Pivot<dp_t > randomOrDefaultPivot = randomPivotManager.GetPivot();
     if(I!=randomOrDefaultPivot.row_ && squaredNorm(randomOrDefaultPivot.value_) > maxNorm2){
       I = randomOrDefaultPivot.row_;
+      delete bCol;
       continue;
     }
 


### PR DESCRIPTION
seems serious because we leak the column size in a loop
this function does not appear to be tested in the examples/tests