### PR TITLE
rk_matrix: fix gcc12 error

### DIFF
--- a/src/rk_matrix.cpp
+++ b/src/rk_matrix.cpp
@@ -984,16 +984,6 @@ RkMatrix<T>* RkMatrix<T>::multiplyRkRk(char trans1, char trans2,
 }
 
 template<typename T>
-size_t RkMatrix<T>::computeRkRkMemorySize(char trans1, char trans2,
-                                                const RkMatrix<T>* r1, const RkMatrix<T>* r2)
-{
-    ScalarArray<T>* b2 = (trans2 == 'N' ? r2->b : r2->a);
-    ScalarArray<T>* a1 = (trans1 == 'N' ? r1->a : r1->b);
-    return b2 == NULL ? 0 : b2->memorySize() +
-           a1 == NULL ? 0 : a1->rows * r2->rank() * sizeof(T);
-}
-
-template<typename T>
 void RkMatrix<T>::multiplyWithDiagOrDiagInv(const HMatrix<T> * d, bool inverse, Side side) {
   assert(*d->rows() == *d->cols());
   assert(side == Side::RIGHT || (*rows == *d->cols()));

--- a/src/rk_matrix.hpp
+++ b/src/rk_matrix.hpp
@@ -278,9 +278,6 @@ public:
   /*! Conjugate the content of the complex matrix */
   void conjugate();
 
-  /** Return the memory size of the a*b product */
-  static size_t computeRkRkMemorySize(char transA, char transB, const RkMatrix<T>* a, const RkMatrix<T>* b);
-
   /** Simpler accessor for the data.
 
       There is only 1 type to because we cant modify the data.


### PR DESCRIPTION
```
src/rk_matrix.cpp:992:15: error: comparing the result of pointer addition ‘(a1 + ((sizetype)(b2->hmat::ScalarArray<float>::memorySize() * 40)))’ and NULL [-Werror=address]
  992 |            a1 == NULL ? 0 : a1->rows * r2->rank() * sizeof(T);
```