### PR TITLE
rk_matrix: workaround gcc12 uninitialized warning

### DIFF
--- a/src/rk_matrix.cpp
+++ b/src/rk_matrix.cpp
@@ -1009,8 +1009,7 @@ template<typename T> void RkMatrix<T>::gemmRk(double epsilon, char transHA, char
     int nbCols = transHB == 'N' ? hb->nrChildCol() : hb->nrChildRow() ; /* Col blocks of the product */
     int nbCom  = transHA == 'N' ? ha->nrChildCol() : ha->nrChildRow() ; /* Common dimension between A and B */
     int nSubRks = nbRows * nbCols;
-    RkMatrix<T>* subRks[nSubRks];
-    std::fill_n(subRks, nSubRks, nullptr);
+    std::vector<RkMatrix<T>*> subRks(nSubRks, nullptr);
     for (int i = 0; i < nbRows; i++) {
       for (int j = 0; j < nbCols; j++) {
         int p = i + j * nbRows;
@@ -1030,9 +1029,8 @@ template<typename T> void RkMatrix<T>::gemmRk(double epsilon, char transHA, char
       } // j loop
     } // i loop
     // Reconstruction of C by adding the parts
-    T alphaV[nSubRks];
-    std::fill_n(alphaV, nSubRks, 1);
-    formattedAddParts(epsilon, alphaV, subRks, nSubRks);
+    std::vector<T> alphaV(nSubRks, 1);
+    formattedAddParts(epsilon, alphaV.data(), subRks.data(), nSubRks);
     for (int i = 0; i < nSubRks; i++) {
       delete subRks[i];
     }


### PR DESCRIPTION
Another (last one) gcc 12 warning, seems like a false positive because alphaV is always entirely initialized:

```
T alphaV[nSubRks];
std::fill_n(alphaV, nSubRks, 1);
formattedAddParts(epsilon, alphaV, subRks, nSubRks);


rk_matrix.cpp:1035:22: error: ‘<unknown>’ may be used uninitialized [-Werror=maybe-uninitialized]
 1035 |     formattedAddParts(epsilon, alphaV, subRks, nSubRks);
      |     ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/io/src/rk_matrix.cpp:501:6: note: by argument 3 of type ‘const double*’ to ‘void hmat::RkMatrix<T>::formattedAddParts(double, const T*, const hmat::RkMatrix<T>* const*, int, bool) [with T = double]’ declared here
  501 | void RkMatrix<T>::formattedAddParts(double epsilon, const T* alpha, const RkMatrix<T>* const * parts,
      |      ^~~~~~~~~~~
```

Nevetherless it may be still be better to use the std::vector ctor instead of a
variable length array in combination with fill_n.

an alternative would be:
```
T alphaV[nSubRks] = { 1 };
```
but that's less c++ish