### PR TITLE
Lapacke: Avoid redefinition warning

### DIFF
--- a/src/lapack_overloads.hpp
+++ b/src/lapack_overloads.hpp
@@ -35,6 +35,7 @@
 #else
   #define armpl_singlecomplex_t hmat::C_t
   #define armpl_doublecomplex_t hmat::Z_t
+  #define LAPACK_COMPLEX_CUSTOM
   #define lapack_complex_float hmat::C_t
   #define lapack_complex_double hmat::Z_t
   // OpenBLAS have a dirty lapack_make_complex_float in a public header


### PR DESCRIPTION
lapacke_config.h (netlib) already have this define:
/usr/x86_64-w64-mingw32/include/lapacke_config.h:64: note: this is the location of the previous definition
   64 | #define lapack_complex_float  _lapack_complex_float