### PR TITLE
MSVC Port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   linux-release-shared:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt-get install -y liblapacke-dev
     - run: cmake -DBUILD_EXAMPLES=ON .
     - run: make -j$(nproc)
@@ -14,7 +14,7 @@ jobs:
   linux-debug-shared:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt-get install -y liblapacke-dev
     - run: cmake -DBUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Debug .
     - run: make -j$(nproc)
@@ -22,7 +22,7 @@ jobs:
   linux-release-static:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt-get install -y liblapacke-dev
     - run: cmake -DBUILD_EXAMPLES=ON -DBUILD_SHARED_LIBS=OFF .
     - run: make -j$(nproc)
@@ -33,7 +33,7 @@ jobs:
       CXX: clang++
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt-get install -y liblapacke-dev
     - run: cmake -DBUILD_EXAMPLES=ON .
     - run: make -j$(nproc)
@@ -43,7 +43,7 @@ jobs:
     env:
       LDFLAGS: -L/usr/local/opt/openblas/lib
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: brew install openblas
     - run: cmake -DBUILD_EXAMPLES=ON -DCBLAS_INCLUDE_DIR=/usr/local/opt/openblas/include .
     - run: make -j$(sysctl -n hw.logicalcpu)
@@ -62,8 +62,21 @@ jobs:
           mingw-w64-x86_64-openblas
           mingw-w64-x86_64-cmake
           mingw-w64-x86_64-ninja
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: cmake -GNinja -DBUILD_EXAMPLES=ON -DCBLAS_INCLUDE_DIR=D:/a/_temp/msys64/mingw64/include/openblas .
     - run: ninja
     - run: ctest
-
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Build
+        shell: cmd
+        run: |
+          curl -fsSLO https://github.com/xianyi/OpenBLAS/releases/download/v0.3.23/OpenBLAS-0.3.23-x64.zip
+          7z x OpenBLAS-0.3.23-x64.zip
+          xcopy /f /y /s bin\libopenblas.dll .
+          cmake -LAH -G Ninja -DBUILD_EXAMPLES=ON -DBLAS_LIBRARIES=%cd:\=/%/lib/libopenblas.dll.a -DCBLAS_LIBRARIES=%cd:\=/%/lib/libopenblas.dll.a -DLAPACKE_LIBRARIES=%cd:\=/%/lib/libopenblas.dll.a -DCBLAS_INCLUDE_DIR=%cd:\=/%/include -DCMAKE_INSTALL_PREFIX=%cd:\=/%/install -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl .
+          cmake --build . --target install --parallel 4
+          ctest --output-on-failure -V

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,9 +279,14 @@ function(hmat_set_compiler_flags _TARGET_NAME)
             endif()
         endforeach()
     endif()
-    check_cxx_compiler_flag("/W4" MSVC_COMPILER_WARNING_FLAGS)
-    if(MSVC_COMPILER_WARNING_FLAGS)
+    check_cxx_compiler_flag("/W4 -wd869,1786,2557,3280" HAVE_INTEL_WIN32_COMPILER_WARNING_FLAGS)
+    if(HAVE_INTEL_WIN32_COMPILER_WARNING_FLAGS)
         target_compile_options(${_TARGET_NAME} PRIVATE /W4 -wd869,1786,2557,3280)
+    endif()
+
+    check_cxx_compiler_flag("/wd4244 /wd4267 /wd4996" HAVE_MSVC_COMPILER_WARNING_FLAGS)
+    if(HAVE_MSVC_COMPILER_WARNING_FLAGS)
+        target_compile_options(${_TARGET_NAME} PRIVATE /wd4244 /wd4267 /wd4996)
     endif()
 
     # C99 required for complex numbers

--- a/examples/c-cylinder.c
+++ b/examples/c-cylinder.c
@@ -30,9 +30,14 @@ typedef std::complex<double> double_complex;
     std::complex<double>(realPart, imagPart)
 #else
 #include <complex.h>
+#ifdef _MSC_VER
+typedef _Dcomplex double_complex;
+#define make_complex(realPart, imagPart) _Cbuild(realPart, imagPart)
+#else
 typedef double complex double_complex;
 #define make_complex(realPart, imagPart) \
     realPart + imagPart * _Complex_I
+#endif
 #endif
 
 #include "hmat/hmat.h"

--- a/examples/c-simple-cylinder.c
+++ b/examples/c-simple-cylinder.c
@@ -30,9 +30,14 @@ typedef std::complex<double> double_complex;
     std::complex<double>(realPart, imagPart)
 #else
 #include <complex.h>
+#ifdef _MSC_VER
+typedef _Dcomplex double_complex;
+#define make_complex(realPart, imagPart) _Cbuild(realPart, imagPart)
+#else
 typedef double complex double_complex;
 #define make_complex(realPart, imagPart) \
     realPart + imagPart * _Complex_I
+#endif
 #endif
 
 #include "hmat/hmat.h"

--- a/examples/c-simple-kriging.c
+++ b/examples/c-simple-kriging.c
@@ -32,7 +32,12 @@
 typedef std::complex<double> double_complex;
 #else
 #include <complex.h>
+#ifdef _MSC_VER
+typedef _Dcomplex double_complex;
+#define make_complex(realPart, imagPart) _Cbuild(realPart, imagPart)
+#else
 typedef double complex double_complex;
+#endif
 #endif
 #include "hmat/hmat.h"
 #include "examples.h"
@@ -42,7 +47,7 @@ typedef double complex double_complex;
 typedef SSIZE_T ssize_t;
 #endif
 
-#if _WIN32
+#ifdef _WIN32
 // getline is not defined in mingw
 #include <stdlib.h>
 size_t getline(char **lineptr, size_t *n, FILE *stream) {

--- a/src/admissibility.hpp
+++ b/src/admissibility.hpp
@@ -46,9 +46,9 @@ public:
   virtual ~AdmissibilityCondition() {}
 
   /*! \brief Precompute ClusterTree::cache_ */
-  virtual void prepare(const ClusterTree& rows, const ClusterTree& cols) const {}
+  virtual void prepare(const ClusterTree& /*rows*/, const ClusterTree& /*cols*/) const {}
   /*! \brief Clean up data which may be allocated by prepare  */
-  virtual void clean(const ClusterTree& rows, const ClusterTree& cols) const {}
+  virtual void clean(const ClusterTree& /*rows*/, const ClusterTree& /*cols*/) const {}
 
   /*! \brief Returns true if the block of interaction between 2 nodes has a
       low-rank representation.

--- a/src/clustering.cpp
+++ b/src/clustering.cpp
@@ -106,13 +106,13 @@ AxisAlignClusteringAlgorithm::largestDimension(const ClusterTree& node, int toAv
 const
 {
   AxisAlignedBoundingBox* bbox = getAxisAlignedBoundingbox(node);
-  int dimension = node.data.coordinates()->dimension();
-  std::pair<double, int> sizeDim[dimension];
+  const int dimension = node.data.coordinates()->dimension();
+  std::vector< std::pair<double, int> > sizeDim(dimension);
   for (int i = 0; i < dimension; i++) {
     sizeDim[i].second = i;
     sizeDim[i].first = bbox->bbMax()[i] - bbox->bbMin()[i];
   }
-  std::sort(sizeDim, sizeDim + dimension);
+  std::sort(sizeDim.data(), sizeDim.data() + dimension);
   if(toAvoid < 0 || dimension < 2 || sizeDim[dimension - 1].second != toAvoid ||
      sizeDim[dimension - 1].first > avoidRatio * sizeDim[dimension - 2].first)
     return sizeDim[dimension - 1].second;

--- a/src/common/my_assert.h
+++ b/src/common/my_assert.h
@@ -69,7 +69,7 @@ HMAT_NORETURN inline static void hmat_assert(const char * format, ...) {
     abort();
 }
 
-#if defined(__cplusplus) && __cplusplus >= 201103L
+#if defined(__cplusplus)
 
 #include <stdexcept>
 #include <string>

--- a/src/common/timeline.hpp
+++ b/src/common/timeline.hpp
@@ -92,7 +92,9 @@ class Timeline {
             HMatrix<T> * block2 = NULL, HMatrix<T> * block3 = NULL){}
         template<typename T> Task(Operation op, ScalarArray<T> * block1,
             HMatrix<T> * block2 = NULL, ScalarArray<T> * block3 = NULL){}
-        Task(Operation op, const int *a=NULL, const int *b=NULL, const int *c=NULL, const int *d=NULL, const int *e=NULL) {}
+        Task(Operation op, const int *a=NULL, const int *b=NULL, const int *c=NULL, const int *d=NULL, const int *e=NULL) {
+            (void)op, (void)a, (void)b, (void)c, (void)d, (void)e; // unused
+        }
 #endif
     };
 
@@ -107,7 +109,9 @@ class Timeline {
      */
     void init(int numberOfWorker=1, int rank=0, bool onlyWorker = false);
 #else
-    void init(int numberOfWorker=1, int rank=0, bool onlyWorker = false){}
+    void init(int numberOfWorker=1, int rank=0, bool onlyWorker = false){
+        (void)numberOfWorker, (void)rank, (void)onlyWorker; // unused
+    }
 #endif
     /** Track pack and unpack */
     void setPackEnabled(bool);

--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -165,7 +165,7 @@ static int findMinRow(const ClusterAssemblyFunction<T>& block,
 
   int rowCount = aRef.rows;
   double minNorm2;
-  int i_ref;
+  int i_ref = -1;
   bool found = false;
 
   while (!found) {
@@ -201,7 +201,7 @@ static int findMinCol(const ClusterAssemblyFunction<T>& block,
                       Vector<typename Types<T>::dp>& col) {
   int colCount = bRef.rows;
   double minNorm2;
-  int j_ref;
+  int j_ref = -1;
   bool found = false;
 
   while (!found) {

--- a/src/full_matrix.hpp
+++ b/src/full_matrix.hpp
@@ -46,9 +46,9 @@ public:
   ScalarArray<T> data;
 private:
   /*! Is this matrix upper triangular? */
-  char triUpper_:1;
+  unsigned char triUpper_:1;
   /*! Is this matrix lower triangular? */
-  char triLower_:1;
+  unsigned char triLower_:1;
   /// Disallow the copy
   FullMatrix(const FullMatrix<T>& o);
 

--- a/src/h_matrix.cpp
+++ b/src/h_matrix.cpp
@@ -638,7 +638,7 @@ bool HMatrix<T>::coarsen(double epsilon, HMatrix<T>* upper, bool force) {
   // leaves. Note that this operation could be used hierarchically.
 
   bool allRkLeaves = true;
-  const RkMatrix<T>* childrenArray[this->nrChild()];
+  std::vector< RkMatrix<T> const* > childrenArray(this->nrChild());
   size_t childrenElements = 0;
   for (int i = 0; i < this->nrChild(); i++) {
     childrenArray[i] = nullptr;
@@ -657,7 +657,7 @@ bool HMatrix<T>::coarsen(double epsilon, HMatrix<T>* upper, bool force) {
   if (allRkLeaves) {
     std::vector<T> alpha(this->nrChild(), 1);
     RkMatrix<T> * candidate = new RkMatrix<T>(NULL, rows(), NULL, cols());
-    candidate->formattedAddParts(epsilon, &alpha[0], childrenArray, this->nrChild());
+    candidate->formattedAddParts(epsilon, &alpha[0], childrenArray.data(), this->nrChild());
     size_t elements = (((size_t) candidate->rows->size()) + candidate->cols->size()) * candidate->rank();
     if (force || elements < childrenElements) {
       // Replace 'this' by the new Rk matrix

--- a/src/h_matrix.hpp
+++ b/src/h_matrix.hpp
@@ -635,7 +635,7 @@ public:
   static bool validationDump;
   /// Error threshold for the compression validation
   static double validationErrorThreshold;
-  short isUpper:1, isLower:1,       /// symmetric, upper or lower stored
+  unsigned short isUpper:1, isLower:1,       /// symmetric, upper or lower stored
        isTriUpper:1, isTriLower:1, /// upper/lower triangular
        keepSameRows:1, keepSameCols:1,
        temporary_:1, ownRowsClusterTree_:1, ownColsClusterTree_:1;

--- a/src/scalar_array.cpp
+++ b/src/scalar_array.cpp
@@ -1142,11 +1142,11 @@ int ScalarArray<T>::productQ(char side, char trans, ScalarArray<T>* c) const {
   // In qrDecomposition(), tau is stored in the last column of 'this'
   // it is not valid to work with 'tau' inside the array 'a' because zunmqr modifies 'a'
   // during computation. So we work on a copy of tau.
-  T tau[std::min(rows, cols)];
-  memcpy(tau, const_ptr(0, cols-1), sizeof(T)*std::min(rows, cols));
+  std::vector<T> tau(std::min(rows, cols));
+  memcpy(tau.data(), const_ptr(0, cols-1), sizeof(T)*std::min(rows, cols));
 
   // We don't use c->ptr() on purpose, because c->is_ortho is preserved here (Q is orthogonal)
-  int info = proxy_lapack_convenience::or_un_mqr(side, trans, c->rows, c->cols, cols, const_ptr(), lda, tau, c->m, c->lda);
+  int info = proxy_lapack_convenience::or_un_mqr(side, trans, c->rows, c->cols, cols, const_ptr(), lda, tau.data(), c->m, c->lda);
   HMAT_ASSERT(!info);
   return 0;
 }
@@ -1175,7 +1175,7 @@ template <typename T> void ScalarArray<T>::cpqrDecomposition(int * &sigma, doubl
   char transA;
   if(std::is_same<Z_t, T>::value || std::is_same<C_t, T>::value) transA='C';
   else transA='T';
-  double normSqrCol[cols];
+  std::vector<double> normSqrCol(cols);
   int pivot=0;
   double max_norm=0;
   for (int i = 0 ; i<cols ; i++)

--- a/src/scalar_array.hpp
+++ b/src/scalar_array.hpp
@@ -89,7 +89,7 @@ template<typename T> class ScalarArray {
 
 private:
   /*! True if the matrix owns its memory, ie has to free it upon destruction */
-  char ownsMemory:1;
+  unsigned char ownsMemory:1;
 protected:
   /// Fortran style pointer (columnwise)
   T* m;
@@ -98,7 +98,7 @@ protected:
   int *is_ortho;
 #endif
   /*! True if we own 'is_ortho' (there are cases where we own the flag and not the memory, with the constructor taking a 'T*' as input) */
-  char ownsFlag:1;
+  unsigned char ownsFlag:1;
 public:
   /// Number of rows
   int rows;
@@ -534,6 +534,8 @@ public:
     *is_ortho = flag;
     static char *test = getenv("HMAT_TEST_ORTHO");
     if (flag && test) assert(getOrtho() == testOrtho());
+#else
+    (void)flag; // unused
 #endif
   }
 


### PR DESCRIPTION
- Avoid usage of VLAs which are unsupported, using std::vector instead
- Fix usage of INTEL flags in cmake
- complex numbers support is not great in msvc, modified examples macros
- fixed some warnings

