### PR TITLE
Allow for UNITY_BUILD

### DIFF
--- a/examples/c-simple-cylinder.c
+++ b/examples/c-simple-cylinder.c
@@ -180,5 +180,6 @@ int main(int argc, char **argv) {
   hmat.destroy(hmatrix);
   hmat_delete_cluster_tree(cluster_tree);
   hmat.finalize();
+  free(points);
   return 0;
 }

--- a/examples/hodlrvsllt.c
+++ b/examples/hodlrvsllt.c
@@ -32,10 +32,10 @@
 #include "common/chrono.h"
 #include "common/my_assert.h"
 
-const static double epsilon = 1e-3;
-const static int nDoF = 3000;
-const static float zero = 0;
-const static float one = 1;
+static const double epsilon = 1e-3;
+static const int nDoF = 3000;
+static const float zero = 0;
+static const float one = 1;
 
 struct context_t {
   int n;

--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -61,10 +61,10 @@ using std::min;
 using std::max;
 
 namespace {
-struct EnvVar {
+struct EnvVarCP {
   /** */
   int logAcaPartialMinSize;
-  EnvVar() {
+  EnvVarCP() {
 	// Enable ACA partial verbose mode for blocks larger than a given size.
     const char * logAcaStr = getenv("HMAT_LOG_ACA_PARTIAL");
     if(logAcaStr == nullptr) {
@@ -74,7 +74,7 @@ struct EnvVar {
     }
   }
 };
-static const EnvVar env;
+static const EnvVarCP envCP;
 } // namespace
 
 namespace hmat {
@@ -389,7 +389,7 @@ doCompressionAcaPartial(const ClusterAssemblyFunction<T>& block, double compress
   const int rowCount = block.rows->size();
   const int colCount = block.cols->size();
   int maxK = min(rowCount, colCount);
-  bool verbose = maxK > env.logAcaPartialMinSize;
+  bool verbose = maxK > envCP.logAcaPartialMinSize;
   // Contains false for the rows that were already used as pivot
   vector<bool> rowFree(rowCount, true);
   int rowPivotCount = 0;

--- a/src/hodlr.cpp
+++ b/src/hodlr.cpp
@@ -25,14 +25,14 @@
 namespace {
 using namespace hmat;
 
-struct EnvVar {
+struct EnvVarHO {
   // Disable the QR algorithm for the symetric HODLR factorization
   bool noQrSym;
-  EnvVar() {
+  EnvVarHO() {
     noQrSym = getenv("HMAT_HODLR_NOQR") != nullptr;
   }
 };
-static const EnvVar env;
+static const EnvVarHO envHO;
 
 template<typename T> void desymmetrize(HMatrix<T> * m) {
   auto m10 = m->get(1,0);
@@ -310,7 +310,7 @@ void factorizeSym(HMatrix<T> * a, HODLRNode<T> * node) {
   solveLowerTriangularLeft(a00, a10->rk()->b, a10->cols()->offset(), node->child0);
   solveLowerTriangularLeft(a11, a10->rk()->a, a10->rows()->offset(), node->child1);
   ScalarArray<T> tmp(r, r, false);
-  if(env.noQrSym) {
+  if(envHO.noQrSym) {
     ScalarArray<T> ata(r, r, false);
     ata.gemm('T', 'N', 1, a10->rk()->a, a10->rk()->a, 0);
     computeSymX11(a10, ata, node, tmp);


### PR DESCRIPTION
To allow for unity/jumbo builds, each occurence of the global variable "EnvVar" must be renamed to avoid conflicts.